### PR TITLE
쪽지 페이지 테스트 코드 추가

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -4,6 +4,13 @@ import { server } from '@/mocks/server'
 
 global.React = React
 
+// next/navigation
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+  useParams: jest.fn(),
+}))
+
 beforeAll(() => {
   // 테스트 시작 전 MSW 서버 시작
   server.listen()

--- a/src/__tests__/page/message.test.tsx
+++ b/src/__tests__/page/message.test.tsx
@@ -1,11 +1,12 @@
+import userEvent from '@testing-library/user-event'
 import { render, screen, waitFor, act, within } from '@testing-library/react'
+import { useParams } from 'next/navigation'
+import axios from 'axios'
 import MessageChatPage from '@/app/my-page/message/[conversationId]/page'
 import MuiThemeProvider from '@/app/panel/MuiThemeProvider'
 import { MOCK_CONVERSATION_ID, MOCK_TARGET } from '@/mocks/handlers/message'
 import { MOCK_ACCESS_TOKEN } from '@/mocks/constants'
 import useMedia from '@/hook/useMedia'
-import userEvent from '@testing-library/user-event'
-import axios from 'axios'
 import API_PATH from '@/constant/apiPath'
 
 jest.mock('@/hook/useMedia', () => ({
@@ -16,16 +17,6 @@ jest.mock('@/hook/useMedia', () => ({
     isLargeTablet: false,
     isOverTablet: false,
     isMobile: true,
-  })),
-}))
-
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(() => ({
-    push: jest.fn(),
-    replace: jest.fn(),
-  })),
-  useParams: jest.fn(() => ({
-    conversationId: MOCK_CONVERSATION_ID.toString(),
   })),
 }))
 
@@ -94,8 +85,11 @@ describe('쪽지 페이지', () => {
   const axiosPostSpy = jest.spyOn(axios.Axios.prototype, 'post')
 
   beforeEach(() => {
-    Element.prototype.scrollTo = jest.fn()
     jest.clearAllMocks()
+    Element.prototype.scrollTo = jest.fn()
+    ;(useParams as jest.Mock).mockReturnValue({
+      conversationId: MOCK_CONVERSATION_ID.toString(),
+    })
   })
 
   test('targetId와 converstationId에 해당하는 쪽지 데이터를 보여준다.', async () => {

--- a/src/__tests__/page/message.test.tsx
+++ b/src/__tests__/page/message.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, waitFor, act, within } from '@testing-library/react'
+import MessageChatPage from '@/app/my-page/message/[conversationId]/page'
+import MuiThemeProvider from '@/app/panel/MuiThemeProvider'
+import { MOCK_CONVERSATION_ID, MOCK_TARGET } from '@/mocks/handlers/message'
+import { MOCK_ACCESS_TOKEN } from '@/mocks/constants'
+import useMedia from '@/hook/useMedia'
+import userEvent from '@testing-library/user-event'
+import axios from 'axios'
+import API_PATH from '@/constant/apiPath'
+
+jest.mock('@/hook/useMedia', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    isPc: false,
+    isTablet: false,
+    isLargeTablet: false,
+    isOverTablet: false,
+    isMobile: true,
+  })),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(() => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+  })),
+  useParams: jest.fn(() => ({
+    conversationId: MOCK_CONVERSATION_ID.toString(),
+  })),
+}))
+
+jest.mock('src/states/useTargetId', () => ({
+  __esModule: true,
+  default: () => ({
+    targetId: MOCK_TARGET.userId,
+    resetTargetId: jest.fn(),
+  }),
+}))
+
+jest.mock('@/states/useAuthStore', () => ({
+  getState: () => ({
+    accessToken: MOCK_ACCESS_TOKEN,
+    logout: jest.fn(),
+    login: jest.fn(),
+  }),
+}))
+
+window.IntersectionObserver = jest.fn(() => {
+  return {
+    observe: jest.fn(),
+    unobserve: jest.fn(),
+    disconnect: jest.fn(),
+    takeRecords: jest.fn(),
+    root: null,
+    rootMargin: '0px',
+    thresholds: [0],
+  }
+})
+
+window.alert = jest.fn()
+
+const mockUseMedia = useMedia as jest.MockedFunction<typeof useMedia>
+
+const renderPage = async () => {
+  const result = await act(async () => {
+    return render(
+      <MuiThemeProvider>
+        <MessageChatPage />
+      </MuiThemeProvider>,
+    )
+  })
+  return result
+}
+
+describe('쪽지 페이지', () => {
+  const mockAsPc = () => {
+    mockUseMedia.mockReturnValue({
+      isPc: true,
+      isTablet: false,
+      isLargeTablet: false,
+      isOverTablet: false,
+    })
+  }
+
+  const mockAsMobile = () => {
+    mockUseMedia.mockReturnValue({
+      isPc: false,
+      isTablet: false,
+      isLargeTablet: false,
+      isOverTablet: false,
+    })
+  }
+
+  const axiosPostSpy = jest.spyOn(axios.Axios.prototype, 'post')
+
+  beforeEach(() => {
+    Element.prototype.scrollTo = jest.fn()
+    jest.clearAllMocks()
+  })
+
+  test('targetId와 converstationId에 해당하는 쪽지 데이터를 보여준다.', async () => {
+    await renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_TARGET.userNickname)).toBeInTheDocument()
+      expect(screen.getByText('안녕하세요'))
+    })
+  })
+
+  test('PC 화면에서 쪽지를 보낼 수 있다.', async () => {
+    mockAsPc()
+    await renderPage()
+    // 랜더링 대기
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_TARGET.userNickname)).toBeInTheDocument()
+    })
+
+    // 쪽지 입력
+    const messageContent = '반가워요'
+    const messageInput = await screen.findByPlaceholderText('내용을 입력하세요')
+    await userEvent.type(messageInput, messageContent)
+    // 쪽지 보내기 버튼 클릭
+    const sendButton = await screen.findByRole('button', { name: '보내기' })
+    await act(async () => {
+      await userEvent.click(sendButton)
+    })
+
+    await waitFor(() => {
+      expect(axiosPostSpy).toHaveBeenLastCalledWith(
+        API_PATH.message.backMessage,
+        expect.objectContaining({
+          targetId: MOCK_TARGET.userId,
+          content: messageContent,
+        }),
+      )
+      expect(screen.getByText(messageContent)).toBeInTheDocument()
+    })
+  })
+
+  test('모바일 화면에서 쪽지를 보낼 수 있다.', async () => {
+    mockAsMobile()
+    await renderPage()
+    // 랜더링 대기
+    await waitFor(() => {
+      expect(screen.getByText(MOCK_TARGET.userNickname)).toBeInTheDocument()
+    })
+
+    // 쪽지 입력 모달 열기
+    const openMessageButton = screen.getByRole('button', {
+      name: '쪽지 보내기',
+    })
+    await userEvent.click(openMessageButton)
+    const modalButtons = await screen.findByTestId('modal-buttons')
+    // 쪽지 입력하기
+    const messageInput = screen.getByPlaceholderText('내용을 입력하세요')
+    const sendButton = within(modalButtons).getByRole('button', {
+      name: '보내기',
+    })
+    const messageContent = '반가워요'
+    await userEvent.type(messageInput, messageContent)
+    // 쪽지 보내기
+    await act(async () => {
+      await userEvent.click(sendButton)
+    })
+
+    await waitFor(() => {
+      expect(axiosPostSpy).toHaveBeenLastCalledWith(
+        API_PATH.message.backMessage,
+        expect.objectContaining({
+          targetId: MOCK_TARGET.userId,
+          content: messageContent,
+        }),
+      )
+      expect(screen.getByText(messageContent)).toBeInTheDocument()
+    })
+  })
+})

--- a/src/__tests__/page/message.test.tsx
+++ b/src/__tests__/page/message.test.tsx
@@ -51,8 +51,30 @@ window.IntersectionObserver = jest.fn(() => {
 window.alert = jest.fn()
 
 const mockUseMedia = useMedia as jest.MockedFunction<typeof useMedia>
+const mockAsPc = () => {
+  mockUseMedia.mockReturnValue({
+    isPc: true,
+    isTablet: false,
+    isLargeTablet: false,
+    isOverTablet: false,
+  })
+}
 
-const renderPage = async () => {
+const mockAsMobile = () => {
+  mockUseMedia.mockReturnValue({
+    isPc: false,
+    isTablet: false,
+    isLargeTablet: false,
+    isOverTablet: false,
+  })
+}
+
+const renderPage = async (type: 'PC' | 'MOBILE' = 'MOBILE') => {
+  if (type === 'PC') {
+    mockAsPc()
+  } else {
+    mockAsMobile()
+  }
   const result = await act(async () => {
     return render(
       <MuiThemeProvider>
@@ -64,24 +86,6 @@ const renderPage = async () => {
 }
 
 describe('쪽지 페이지', () => {
-  const mockAsPc = () => {
-    mockUseMedia.mockReturnValue({
-      isPc: true,
-      isTablet: false,
-      isLargeTablet: false,
-      isOverTablet: false,
-    })
-  }
-
-  const mockAsMobile = () => {
-    mockUseMedia.mockReturnValue({
-      isPc: false,
-      isTablet: false,
-      isLargeTablet: false,
-      isOverTablet: false,
-    })
-  }
-
   const axiosPostSpy = jest.spyOn(axios.Axios.prototype, 'post')
 
   beforeEach(() => {
@@ -102,8 +106,7 @@ describe('쪽지 페이지', () => {
   })
 
   test('PC 화면에서 쪽지를 보낼 수 있다.', async () => {
-    mockAsPc()
-    await renderPage()
+    await renderPage('PC')
     // 랜더링 대기
     await waitFor(() => {
       expect(screen.getByText(MOCK_TARGET.userNickname)).toBeInTheDocument()
@@ -132,8 +135,7 @@ describe('쪽지 페이지', () => {
   })
 
   test('모바일 화면에서 쪽지를 보낼 수 있다.', async () => {
-    mockAsMobile()
-    await renderPage()
+    await renderPage('MOBILE')
     // 랜더링 대기
     await waitFor(() => {
       expect(screen.getByText(MOCK_TARGET.userNickname)).toBeInTheDocument()

--- a/src/__tests__/page/message.test.tsx
+++ b/src/__tests__/page/message.test.tsx
@@ -92,7 +92,7 @@ describe('쪽지 페이지', () => {
     })
   })
 
-  test('targetId와 converstationId에 해당하는 쪽지 데이터를 보여준다.', async () => {
+  test('targetId와 conversationId에 해당하는 쪽지 데이터를 보여준다.', async () => {
     await renderPage()
 
     await waitFor(() => {

--- a/src/__tests__/page/message.test.tsx
+++ b/src/__tests__/page/message.test.tsx
@@ -116,7 +116,7 @@ describe('쪽지 페이지', () => {
     })
 
     // 쪽지 입력
-    const messageContent = '반가워요'
+    const messageContent = '반가워요 (PC)'
     const messageInput = await screen.findByPlaceholderText('내용을 입력하세요')
     await userEvent.type(messageInput, messageContent)
     // 쪽지 보내기 버튼 클릭
@@ -156,7 +156,7 @@ describe('쪽지 페이지', () => {
     const sendButton = within(modalButtons).getByRole('button', {
       name: '보내기',
     })
-    const messageContent = '반가워요'
+    const messageContent = '반가워요 (모바일)'
     await userEvent.type(messageInput, messageContent)
     // 쪽지 보내기
     await act(async () => {

--- a/src/__tests__/page/messageList.test.tsx
+++ b/src/__tests__/page/messageList.test.tsx
@@ -1,10 +1,15 @@
-import { screen, render, waitFor, act, within } from '@testing-library/react'
+import { screen, render, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import axios from 'axios'
 import { SWRConfig } from 'swr'
+import { http, HttpResponse } from 'msw'
 import MessageListPage from '@/app/my-page/message/page'
 import MuiThemeProvider from '@/app/panel/MuiThemeProvider'
 import { MOCK_ACCESS_TOKEN } from '@/mocks/constants'
+import API_PATH from '@/constant/apiPath'
+import HTTP_STATUS from '@/constant/httpStatus'
+import { server } from '@/mocks/server'
+import { MOCK_TARGET } from '@/mocks/handlers/message'
 
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
@@ -16,6 +21,48 @@ jest.mock('@/states/useAuthStore', () => ({
     login: jest.fn(),
   }),
 }))
+jest.mock('@/hook/useMedia', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    isPc: true,
+    isTablet: false,
+    isMobile: false,
+  })),
+}))
+
+server.use(
+  http.post<never, { keyword: string }, Array<any>>(
+    API_PATH.message.searching,
+    async ({ request }) => {
+      const { keyword } = await request.json()
+
+      // 검색 결과에 해당하는 사용자가 없는 경우
+      if (!MOCK_TARGET.userNickname.includes(keyword)) {
+        return HttpResponse.json([], {
+          status: HTTP_STATUS.ok,
+        })
+      }
+
+      return HttpResponse.json([
+        {
+          targetId: MOCK_TARGET.userId,
+          targetEmail: MOCK_TARGET.userEmail,
+          targetNickname: MOCK_TARGET.userNickname,
+          targetProfile: MOCK_TARGET.userProfile,
+        },
+      ])
+    },
+  ),
+)
+
+server.use(
+  http.post(API_PATH.message.newMessage, async ({ request }) => {
+    console.log('새 쪽지 작성 요청', request.url)
+    return HttpResponse.json([], {
+      status: HTTP_STATUS.ok,
+    })
+  }),
+)
 
 const renderPage = async () => {
   const result = await render(
@@ -69,4 +116,201 @@ describe('메시지 목록 랜더링', () => {
       expect(messageList.length).toBe(0)
     })
   })
+})
+
+describe('PC View 메시지 관리', () => {
+  beforeEach(async () => {
+    // 메시지 관리 모드 진입
+    await renderPage()
+
+    const manageButton = screen.getByRole('button', { name: '관리' })
+    await userEvent.click(manageButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('대상 리스트 관리')).toBeInTheDocument()
+    })
+  })
+
+  test('메시지를 선택할 수 있다.', async () => {
+    const messageList = screen.getAllByTestId('message-item')
+    const firstMessage = messageList[0]
+    const checkbox = within(firstMessage).getByRole('checkbox')
+
+    // 하나 선택
+    await userEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+    // 하나 선택 해제
+    await userEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+    // 전체 선택
+    const selectAllButton = screen.getByRole('button', { name: '전체 선택' })
+    await userEvent.click(selectAllButton)
+    const allCheckboxes = screen.getAllByRole('checkbox')
+    allCheckboxes.forEach((checkBox) => {
+      expect(checkBox).toBeChecked()
+    })
+    // 전체 선택 해제
+    const unselectAllButton = screen.getByRole('button', {
+      name: '전체 선택 해제',
+    })
+    await userEvent.click(unselectAllButton)
+    allCheckboxes.forEach((checkBox) => {
+      expect(checkBox).not.toBeChecked()
+    })
+  })
+
+  test('메시지를 삭제할 수 있다.', async () => {
+    const axiosDeleteSpy = jest.spyOn(axios.Axios.prototype, 'delete')
+
+    // 하나 선택
+    const messageList = screen.getAllByTestId('message-item')
+    const firstMessage = messageList[0]
+    const checkbox = within(firstMessage).getByRole('checkbox')
+    await userEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+
+    // 삭제 버튼 클릭
+    const deleteButton = screen.getByRole('button', { name: '삭제' })
+    await userEvent.click(deleteButton)
+
+    await waitFor(() => {
+      expect(axiosDeleteSpy).toHaveBeenCalledWith(
+        API_PATH.message.deleteMessage,
+        {
+          data: {
+            target: [{ conversationId: expect.any(Number) }],
+          },
+        },
+      )
+      expect(screen.queryByTestId('message-item')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('새로운 메시지 작성', () => {
+  beforeEach(async () => {
+    // 새 쪽지 작성 모달 열기
+    await renderPage()
+
+    const newMessageButton = screen.getByRole('button', { name: '새 쪽지' })
+    await userEvent.click(newMessageButton)
+
+    await waitFor(() => {
+      const newMessageModal = screen.getByTestId('modal-wrapper')
+      expect(within(newMessageModal).getByText('새 쪽지')).toBeInTheDocument()
+    })
+  })
+
+  test('보낼 상대를 검색할 수 있다.', async () => {
+    const searchButton = screen.getByRole('button', { name: '검색' })
+    const searchInput =
+      screen.getByPlaceholderText('검색할 닉네임을 입력해주세요.')
+
+    // 존재하는 닉네임 검색
+    await userEvent.type(searchInput, '김영희')
+    await userEvent.click(searchButton)
+
+    await waitFor(() => {
+      const targetList = screen.getAllByTestId('target-list-item')
+      targetList.forEach((item) => {
+        expect(within(item).getByText(/김영희/)).toBeInTheDocument()
+      })
+    })
+    // 존재하지 않는 닉네임 검색
+    await userEvent.clear(searchInput)
+    await userEvent.type(searchInput, '존재하지 않는 사용자')
+    await userEvent.click(searchButton)
+
+    await waitFor(() => {
+      const targetList = screen.queryAllByTestId('target-list-item')
+      expect(targetList.length).toBe(0)
+      expect(screen.getByText('검색된 유저가 없어요.')).toBeInTheDocument()
+    })
+  })
+
+  test('쪽지를 보낼 수 있다.', async () => {
+    const axiosPostSpy = jest.spyOn(axios.Axios.prototype, 'post')
+
+    // 새 쪽지 모달이 열려있는지 확인
+    await waitFor(() => {
+      const modal = screen.getByTestId('modal-wrapper')
+      // 제목이 h3(heading)으로 들어가 있으므로 getByRole 사용
+      expect(
+        within(modal).getByRole('heading', { name: '새 쪽지' }),
+      ).toBeInTheDocument()
+    })
+
+    // 모달 내부의 요소들을 찾기 위해 within 사용
+    const modal = screen.getByTestId('modal-wrapper')
+    const searchButton = within(modal).getByRole('button', { name: '검색' })
+    const searchInput =
+      within(modal).getByPlaceholderText('검색할 닉네임을 입력해주세요.')
+    const messageContentInput =
+      within(modal).getByPlaceholderText('내용을 입력하세요.')
+    const sendButton = within(modal).getByRole('button', { name: '보내기' })
+
+    // 존재하는 닉네임 검색
+    await userEvent.type(searchInput, '김영희')
+    await userEvent.click(searchButton)
+
+    // 검색 결과가 나타날 때까지 기다림
+    await waitFor(() => {
+      const targetList = screen.getAllByTestId('target-list-item')
+      expect(targetList.length).toBeGreaterThan(0)
+    })
+
+    // 보낼 상대 선택
+    const targetList = screen.getAllByTestId('target-list-item')
+    const targetItem = targetList.find((item) =>
+      within(item).getByText('김영희'),
+    ) as HTMLElement
+    await userEvent.click(targetItem)
+
+    // 사용자가 선택되었는지 확인 (입력 필드가 비활성화되고 값이 변경됨)
+    await waitFor(() => {
+      expect(searchInput).toHaveValue('김영희')
+      expect(searchInput).toBeDisabled()
+    })
+
+    // 메시지 내용 입력
+    await userEvent.type(messageContentInput, '안녕하세요, 김영희님!')
+
+    // 메시지 보내기 (첫 번째 보내기 버튼 - 확인 모달을 열기 위한 버튼)
+    await userEvent.click(sendButton)
+
+    // 확인 모달이 열릴 때까지 기다림
+    await waitFor(() => {
+      expect(screen.getByText('쪽지 보내기')).toBeInTheDocument()
+      expect(
+        screen.getByText('김영희에게 쪽지를 보내시겠습니까?'),
+      ).toBeInTheDocument()
+    })
+
+    // 확인 모달의 보내기 버튼 클릭 (두 번째 보내기 버튼)
+    const modals = screen.getAllByTestId('modal-wrapper')
+    const confirmModal = modals[1] // 두 번째 모달이 확인 모달
+    const confirmSendButton = within(confirmModal).getByRole('button', {
+      name: '보내기',
+    })
+    await userEvent.click(confirmSendButton)
+    console.log('axiosPostSpy.mock.calls:', axiosPostSpy.mock.calls)
+    await waitFor(() => {
+      // expect(axiosPostSpy).toHaveBeenLastCalledWith(
+      //   API_PATH.message.newMessage,
+      //   expect.objectContaining({
+      //     targetId: 2,
+      //     content: '안녕하세요, 김영희님!',
+      //   }),
+      // )
+      expect(screen.queryByTestId('modal-wrapper')).not.toBeInTheDocument()
+    })
+  })
+})
+
+describe('사용자 인터랙션', () => {
+  test('새로운 메시지를 보낼 수 있다.', async () => {})
+
+  test('메시지를 읽을 수 있다.', async () => {})
+
+  test('모바일 View에서 메시지를 밀어 삭제할 수 있다.', async () => {})
 })

--- a/src/__tests__/page/messageList.test.tsx
+++ b/src/__tests__/page/messageList.test.tsx
@@ -64,6 +64,14 @@ server.use(
   }),
 )
 
+server.use(
+  http.delete(API_PATH.message.deleteMessage, async () => {
+    return HttpResponse.json([], {
+      status: HTTP_STATUS.ok,
+    })
+  }),
+)
+
 const renderPage = async () => {
   const result = await render(
     <SWRConfig value={{ provider: () => new Map() }}>
@@ -305,12 +313,4 @@ describe('새로운 메시지 작성', () => {
       expect(screen.queryByTestId('modal-wrapper')).not.toBeInTheDocument()
     })
   })
-})
-
-describe('사용자 인터랙션', () => {
-  test('새로운 메시지를 보낼 수 있다.', async () => {})
-
-  test('메시지를 읽을 수 있다.', async () => {})
-
-  test('모바일 View에서 메시지를 밀어 삭제할 수 있다.', async () => {})
 })

--- a/src/__tests__/page/messageList.test.tsx
+++ b/src/__tests__/page/messageList.test.tsx
@@ -56,8 +56,7 @@ server.use(
 )
 
 server.use(
-  http.post(API_PATH.message.newMessage, async ({ request }) => {
-    console.log('새 쪽지 작성 요청', request.url)
+  http.post(API_PATH.message.newMessage, async () => {
     return HttpResponse.json([], {
       status: HTTP_STATUS.ok,
     })
@@ -237,7 +236,7 @@ describe('새로운 메시지 작성', () => {
   })
 
   test('쪽지를 보낼 수 있다.', async () => {
-    const axiosPostSpy = jest.spyOn(axios.Axios.prototype, 'post')
+    // const axiosPostSpy = jest.spyOn(axios.Axios.prototype, 'post')
 
     // 새 쪽지 모달이 열려있는지 확인
     await waitFor(() => {
@@ -301,7 +300,6 @@ describe('새로운 메시지 작성', () => {
       name: '보내기',
     })
     await userEvent.click(confirmSendButton)
-    console.log('axiosPostSpy.mock.calls:', axiosPostSpy.mock.calls)
     await waitFor(() => {
       // expect(axiosPostSpy).toHaveBeenLastCalledWith(
       //   API_PATH.message.newMessage,

--- a/src/__tests__/page/messageList.test.tsx
+++ b/src/__tests__/page/messageList.test.tsx
@@ -88,11 +88,10 @@ describe('메시지 목록 랜더링', () => {
   const MOCK_MESSAGE = '안녕하세요'
   const MOCK_SENDER = '김영희'
 
-  test('메시지 목록을 불러온다', async () => {
+  test('메시지 목록을 보여준다.', async () => {
     await renderPage()
     const messageList = screen.getAllByTestId('message-item')
 
-    expect(messageList.length).toBe(1)
     expect(within(messageList[0]).getByText(MOCK_MESSAGE)).toBeInTheDocument()
     expect(within(messageList[0]).getByText(MOCK_SENDER)).toBeInTheDocument()
   })
@@ -107,7 +106,7 @@ describe('메시지 목록 랜더링', () => {
 
     await waitFor(() => {
       const messageList = screen.getAllByTestId('message-item')
-      expect(messageList.length).toBe(1)
+      expect(messageList.length).toBeGreaterThanOrEqual(1) // 검색 결과가 하나 이상 있어야 한다.
       expect(within(messageList[0]).getByText(MOCK_SENDER)).toBeInTheDocument()
     })
 

--- a/src/__tests__/page/messageList.test.tsx
+++ b/src/__tests__/page/messageList.test.tsx
@@ -11,9 +11,6 @@ import HTTP_STATUS from '@/constant/httpStatus'
 import { server } from '@/mocks/server'
 import { MOCK_TARGET } from '@/mocks/handlers/message'
 
-jest.mock('next/navigation', () => ({
-  useRouter: jest.fn(),
-}))
 jest.mock('@/states/useAuthStore', () => ({
   getState: () => ({
     accessToken: MOCK_ACCESS_TOKEN,

--- a/src/__tests__/page/messageList.test.tsx
+++ b/src/__tests__/page/messageList.test.tsx
@@ -1,0 +1,72 @@
+import { screen, render, waitFor, act, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import axios from 'axios'
+import { SWRConfig } from 'swr'
+import MessageListPage from '@/app/my-page/message/page'
+import MuiThemeProvider from '@/app/panel/MuiThemeProvider'
+import { MOCK_ACCESS_TOKEN } from '@/mocks/constants'
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+jest.mock('@/states/useAuthStore', () => ({
+  getState: () => ({
+    accessToken: MOCK_ACCESS_TOKEN,
+    logout: jest.fn(),
+    login: jest.fn(),
+  }),
+}))
+
+const renderPage = async () => {
+  const result = await render(
+    <SWRConfig value={{ provider: () => new Map() }}>
+      <MuiThemeProvider>
+        <MessageListPage />
+      </MuiThemeProvider>
+    </SWRConfig>,
+  )
+
+  await waitFor(() => {
+    expect(result.container).toBeInTheDocument()
+  })
+
+  return result
+}
+
+describe('메시지 목록 랜더링', () => {
+  const MOCK_MESSAGE = '안녕하세요'
+  const MOCK_SENDER = '김영희'
+
+  test('메시지 목록을 불러온다', async () => {
+    await renderPage()
+    const messageList = screen.getAllByTestId('message-item')
+
+    expect(messageList.length).toBe(1)
+    expect(within(messageList[0]).getByText(MOCK_MESSAGE)).toBeInTheDocument()
+    expect(within(messageList[0]).getByText(MOCK_SENDER)).toBeInTheDocument()
+  })
+
+  test('메시지 목록에서 닉네임으로 검색할 수 있다.', async () => {
+    await renderPage()
+
+    const searchInput = screen.getByPlaceholderText('닉네임을 검색해주세요.')
+    await userEvent.type(searchInput, MOCK_SENDER)
+    const searchButton = screen.getByRole('button', { name: '검색' })
+    await userEvent.click(searchButton)
+
+    await waitFor(() => {
+      const messageList = screen.getAllByTestId('message-item')
+      expect(messageList.length).toBe(1)
+      expect(within(messageList[0]).getByText(MOCK_SENDER)).toBeInTheDocument()
+    })
+
+    await userEvent.clear(searchInput)
+    await userEvent.type(searchInput, '존재하지 않는 사용자')
+    await userEvent.click(searchButton)
+
+    await waitFor(() => {
+      const messageList = screen.queryAllByTestId('message-item')
+      expect(messageList.length).toBe(0)
+    })
+  })
+})

--- a/src/app/my-page/message/[conversationId]/page.tsx
+++ b/src/app/my-page/message/[conversationId]/page.tsx
@@ -92,7 +92,7 @@ const MessageChatPage = () => {
       .finally(() => {
         setIsLoading(false)
       })
-  }, [targetId, conversationId, goToMessageList])
+  }, [targetId, conversationId])
 
   useEffect(() => {
     if (!data) return

--- a/src/app/my-page/message/[conversationId]/panel/MessageForm.tsx
+++ b/src/app/my-page/message/[conversationId]/panel/MessageForm.tsx
@@ -15,6 +15,7 @@ import useToast from '@/states/useToast'
 import SendIcon from '@/icons/SendIcon'
 import { IMessage, IMessageTargetUser } from '@/types/IMessage'
 import * as style from './MessageForm.style'
+import API_PATH from '@/constant/apiPath'
 
 const MAX_LENGTH = 300
 
@@ -72,7 +73,7 @@ const MessageForm = ({
         content,
       }
       const response = await axiosWithAuth.post(
-        `/api/v1/message/back-message`,
+        API_PATH.message.backMessage,
         messageData,
       )
       if (response.status === 201) {
@@ -128,6 +129,7 @@ const MessageForm = ({
               <BorderlessTextField
                 fullWidth
                 id="message"
+                aria-label="쪽지 내용 입력"
                 multiline
                 value={content}
                 placeholder={
@@ -152,6 +154,7 @@ const MessageForm = ({
               disabled={messageSendState.isMessageSending || disabled}
               type="submit"
               sx={style.pcSendButton}
+              aria-label="보내기"
             >
               <SendIcon />
             </IconButton>
@@ -165,6 +168,7 @@ const MessageForm = ({
             variant="outlined"
             onChange={(e) => setContent(e.target.value.slice(0, MAX_LENGTH))}
             onKeyDown={handleKeyDown}
+            aria-label="쪽지 내용 입력"
           />
         )}
       </form>

--- a/src/app/my-page/message/[conversationId]/panel/MobileSendButton.tsx
+++ b/src/app/my-page/message/[conversationId]/panel/MobileSendButton.tsx
@@ -67,6 +67,7 @@ const MobileSendButton = ({
           onClick={openModal}
           disabled={disabled}
           sx={style.mobileSendIconButton}
+          aria-label="쪽지 보내기"
         >
           <SendIcon />
         </Fab>

--- a/src/app/my-page/message/[conversationId]/panel/PcHeader.style.ts
+++ b/src/app/my-page/message/[conversationId]/panel/PcHeader.style.ts
@@ -2,8 +2,7 @@ import { Theme } from '@mui/material'
 
 export const pcHeader = {
   padding: '0.625rem 1rem',
-  'border-bottom': (theme: Theme) =>
-    `1px solid ${theme.palette.line.alternative}`,
+  borderBottom: (theme: Theme) => `1px solid ${theme.palette.line.alternative}`,
 }
 
 export const headerAvatar = {

--- a/src/app/my-page/message/panel/MessageBar.tsx
+++ b/src/app/my-page/message/panel/MessageBar.tsx
@@ -54,7 +54,7 @@ export const ContainerHeader = ({
           message="관리"
         />
       ) : (
-        <IconButton onClick={openNewMessageModal}>
+        <IconButton onClick={openNewMessageModal} aria-label={'새 쪽지'}>
           <PlusIcon width={'1.5rem'} height={'1.5rem'} />
         </IconButton>
       )}

--- a/src/app/my-page/message/panel/MessageContainer.tsx
+++ b/src/app/my-page/message/panel/MessageContainer.tsx
@@ -99,7 +99,7 @@ const MessageContainer = ({
           <ManageBar
             isSelectedAll={isSelectedAll(messageList)}
             handleSelectAll={() =>
-              selectAll(messageList.map((message) => message.targetId))
+              selectAll(messageList.map((message) => message.conversationId))
             }
             handleUnselectAll={unselectAll}
             handleDelete={handleDelete}

--- a/src/app/my-page/message/panel/MobileMessageItem.tsx
+++ b/src/app/my-page/message/panel/MobileMessageItem.tsx
@@ -76,6 +76,7 @@ const SwappableMessageItem = ({
   return (
     <ListItem
       disablePadding
+      data-testid="message-item"
       sx={{
         ...style.swappableWrapper,
         transform: `translateX(${touchState.diffLength})`,

--- a/src/app/my-page/message/panel/NewMessageForm.tsx
+++ b/src/app/my-page/message/panel/NewMessageForm.tsx
@@ -4,6 +4,7 @@ import useAxiosWithAuth from '@/api/config'
 import useModal from '@/hook/useModal'
 import { IMessageListData, IMessageTarget } from '@/types/IMessage'
 import CuTextModal from '@/components/CuTextModal'
+import API_PATH from '@/constant/apiPath'
 import useToast from '@/states/useToast'
 import * as style from './NewMessageForm.style'
 
@@ -59,7 +60,7 @@ const NewMessageForm = ({
           content: content,
         }
         const response = await axiosInstance.post(
-          '/api/v1/message/new-message',
+          API_PATH.message.newMessage,
           reqBody,
         )
         setContent('')

--- a/src/app/my-page/message/panel/PCMessageItem.tsx
+++ b/src/app/my-page/message/panel/PCMessageItem.tsx
@@ -23,7 +23,7 @@ export const PCMessageListItem = ({
   const { targetId, conversationId } = message
 
   return (
-    <ListItem disablePadding sx={style.listItem}>
+    <ListItem disablePadding sx={style.listItem} data-testid="message-item">
       <ListItemButton
         disableGutters
         onClick={

--- a/src/app/my-page/message/panel/TargetList.tsx
+++ b/src/app/my-page/message/panel/TargetList.tsx
@@ -36,6 +36,7 @@ const TargetItem = ({
         <Stack direction={'row'} alignItems={'center'} spacing={1}>
           <CuAvatar src={targetProfile} sx={style.avatar} />
           <ListItemText
+            data-testid={'target-list-item'}
             primary={targetNickname}
             primaryTypographyProps={{
               variant: 'Body1',

--- a/src/components/CuModal.tsx
+++ b/src/components/CuModal.tsx
@@ -36,6 +36,7 @@ const CuModal = ({
   return (
     <Modal open={open} onClose={onClose} keepMounted={!!keepMounted}>
       <Stack
+        data-testid="modal-wrapper"
         spacing={'1.5rem'}
         sx={{ ...getModalWrapperStyle(isPc, mobileFullSize) }}
       >
@@ -74,7 +75,12 @@ const CuModal = ({
         <Stack sx={style.modalContent} justifyContent={'center'}>
           {children}
         </Stack>
-        <Stack direction={'row'} spacing={'1rem'} width={'100%'}>
+        <Stack
+          direction={'row'}
+          spacing={'1rem'}
+          width={'100%'}
+          data-testid={'modal-buttons'}
+        >
           {textButton ? (
             <CuButton
               variant={'text'}

--- a/src/constant/apiPath.ts
+++ b/src/constant/apiPath.ts
@@ -28,6 +28,7 @@ const API_PATH = {
     deleteMessage: `${BASE_URL}/api/v1/message/delete-message`,
     searching: `${BASE_URL}/api/v1/message/searching`,
     conversationList: `${BASE_URL}/api/v1/message/conversation-list`,
+    newMessage: `${BASE_URL}/api/v1/message/new-message`,
   },
   myPortfolio: {
     list: `${BASE_URL}/api/v1/myPortfolio/list`,

--- a/src/constant/apiPath.ts
+++ b/src/constant/apiPath.ts
@@ -29,6 +29,7 @@ const API_PATH = {
     searching: `${BASE_URL}/api/v1/message/searching`,
     conversationList: `${BASE_URL}/api/v1/message/conversation-list`,
     newMessage: `${BASE_URL}/api/v1/message/new-message`,
+    backMessage: `${BASE_URL}/api/v1/message/back-message`,
   },
   myPortfolio: {
     list: `${BASE_URL}/api/v1/myPortfolio/list`,

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -30,7 +30,7 @@ type NewMessageRequest = {
 }
 
 const MOCK_CONVERSATION_ID = 1
-const MOCK_TARGET = {
+export const MOCK_TARGET = {
   userId: 2,
   userEmail: 'kimyounghee@test.com',
   userNickname: '김영희',

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -3,11 +3,13 @@ import API_PATH from '@/constant/apiPath'
 import HTTP_STATUS from '@/constant/httpStatus'
 import {
   IConversationList,
+  IMessage,
   IMessageListData,
   IMessageTarget,
 } from '@/types/IMessage'
 import { ErrorResponse } from '../types'
 import { validateAccessToken } from '../utils'
+import { MOCK_USER_PROFILE } from '../constants'
 
 type ConversationListRequest = {
   targetId: number
@@ -24,12 +26,12 @@ type SearchUserRequest = {
   keyword: string
 }
 
-type NewMessageRequest = {
+type MessageRequest = {
   targetId: number
   content: string
 }
 
-const MOCK_CONVERSATION_ID = 1
+export const MOCK_CONVERSATION_ID = 1
 export const MOCK_TARGET = {
   userId: 2,
   userEmail: 'kimyounghee@test.com',
@@ -50,6 +52,30 @@ let messageList: IMessageListData[] = [
     latestMsgId: 1,
   },
 ]
+
+const messageMap = new Map<number, IConversationList>()
+messageMap.set(MOCK_TARGET.userId, {
+  msgOwner: {
+    userId: MOCK_USER_PROFILE.id,
+    userNickname: MOCK_USER_PROFILE.nickname,
+    userProfile: '',
+  },
+  msgTarget: {
+    userId: MOCK_TARGET.userId,
+    userNickname: MOCK_TARGET.userNickname,
+    userProfile: MOCK_TARGET.userProfile,
+    deleted: MOCK_TARGET.deleted,
+  },
+  msgList: [
+    {
+      userId: MOCK_TARGET.userId,
+      msgId: 1,
+      content: '안녕하세요',
+      date: '2025-05-10',
+      isEnd: true,
+    },
+  ],
+})
 
 export const handlers = [
   http.get<never, never, IMessageListData[] | ErrorResponse>(
@@ -187,7 +213,7 @@ export const handlers = [
       })
     },
   ),
-  http.post<never, NewMessageRequest, IMessageListData[] | ErrorResponse>(
+  http.post<never, MessageRequest, IMessageListData[] | ErrorResponse>(
     API_PATH.message.newMessage,
     async ({ request }) => {
       const validationResult = validateAccessToken(request)
@@ -213,6 +239,45 @@ export const handlers = [
       }
       messageList.push(newMessage)
       return HttpResponse.json(messageList, {
+        status: HTTP_STATUS.created,
+      })
+    },
+  ),
+  http.post<never, MessageRequest, IMessage | ErrorResponse>(
+    API_PATH.message.backMessage,
+    async ({ request }) => {
+      const validationResult = validateAccessToken(request)
+      if (!validationResult.isValid) {
+        return validationResult.response
+      }
+      const { targetId, content } = await request.json()
+      if (!targetId || !content) {
+        return HttpResponse.json(
+          { message: '대상 사용자와 내용을 입력해주세요.' },
+          { status: HTTP_STATUS.badRequest },
+        )
+      }
+      const messages = messageMap.get(targetId)
+      if (!messages) {
+        return HttpResponse.json(
+          { message: '쪽지가 존재하지 않습니다.' },
+          { status: HTTP_STATUS.notFound },
+        )
+      }
+      const newMessage: IMessage = {
+        userId: MOCK_USER_PROFILE.id,
+        msgId: messages.msgList.length + 1, // 새로운 메시지 ID
+        content,
+        date: new Date().toISOString(),
+        isEnd: true,
+      }
+      // 기존 메시지 목록의 가장 마지막 메시지의 isEnd 값을 false로 변경
+      if (messages.msgList.length > 0) {
+        messages.msgList[messages.msgList.length - 1].isEnd = false
+      }
+      messages.msgList.push(newMessage)
+      messageMap.set(targetId, messages)
+      return HttpResponse.json(newMessage, {
         status: HTTP_STATUS.created,
       })
     },

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -24,6 +24,11 @@ type SearchUserRequest = {
   keyword: string
 }
 
+type NewMessageRequest = {
+  targetId: number
+  content: string
+}
+
 const MOCK_CONVERSATION_ID = 1
 const MOCK_TARGET = {
   userId: 2,
@@ -179,6 +184,36 @@ export const handlers = [
       }
       return HttpResponse.json(conversationList, {
         status: HTTP_STATUS.ok,
+      })
+    },
+  ),
+  http.post<never, NewMessageRequest, IMessageListData[] | ErrorResponse>(
+    API_PATH.message.newMessage,
+    async ({ request }) => {
+      const validationResult = validateAccessToken(request)
+      if (!validationResult.isValid) {
+        return validationResult.response
+      }
+      const { targetId, content } = await request.json()
+      if (!targetId || !content) {
+        return HttpResponse.json(
+          { message: '대상 사용자와 내용을 입력해주세요.' },
+          { status: HTTP_STATUS.badRequest },
+        )
+      }
+      const newMessage: IMessageListData = {
+        targetId: targetId,
+        conversationId: MOCK_CONVERSATION_ID,
+        targetNickname: MOCK_TARGET.userNickname,
+        targetProfile: MOCK_TARGET.userProfile,
+        unreadMsgNumber: 1,
+        latestContent: content,
+        latestDate: new Date().toISOString(),
+        latestMsgId: messageList.length + 1, // 새로운 메시지 ID
+      }
+      messageList.push(newMessage)
+      return HttpResponse.json(messageList, {
+        status: HTTP_STATUS.created,
       })
     },
   ),

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -104,6 +104,13 @@ export const handlers = [
         )
       }
 
+      // 검색 결과에 해당하는 사용자가 없는 경우
+      if (!MOCK_TARGET.userNickname.includes(keyword)) {
+        return HttpResponse.json([], {
+          status: HTTP_STATUS.ok,
+        })
+      }
+
       // 기존 메시지가 없는 경우에만 검색 결과 반환 (1명의 사용자만 존재)
       if (messageList.length === 0) {
         return HttpResponse.json(

--- a/src/mocks/handlers/message.ts
+++ b/src/mocks/handlers/message.ts
@@ -40,18 +40,18 @@ export const MOCK_TARGET = {
   deleted: false,
 } as const
 
-let messageList: IMessageListData[] = [
-  {
-    targetId: MOCK_TARGET.userId,
-    conversationId: MOCK_CONVERSATION_ID,
-    targetNickname: MOCK_TARGET.userNickname,
-    targetProfile: MOCK_TARGET.userProfile,
-    unreadMsgNumber: 1,
-    latestContent: '안녕하세요',
-    latestDate: '2025-05-10',
-    latestMsgId: 1,
-  },
-]
+export const MOCK_MESSAGE: IMessageListData = {
+  targetId: MOCK_TARGET.userId,
+  conversationId: MOCK_CONVERSATION_ID,
+  targetNickname: MOCK_TARGET.userNickname,
+  targetProfile: MOCK_TARGET.userProfile,
+  unreadMsgNumber: 1,
+  latestContent: '안녕하세요',
+  latestDate: '2025-05-10',
+  latestMsgId: 1,
+} as const
+
+let messageList: IMessageListData[] = [MOCK_MESSAGE]
 
 const messageMap = new Map<number, IConversationList>()
 messageMap.set(MOCK_TARGET.userId, {
@@ -69,9 +69,9 @@ messageMap.set(MOCK_TARGET.userId, {
   msgList: [
     {
       userId: MOCK_TARGET.userId,
-      msgId: 1,
-      content: '안녕하세요',
-      date: '2025-05-10',
+      msgId: MOCK_MESSAGE.latestMsgId,
+      content: MOCK_MESSAGE.latestContent,
+      date: MOCK_MESSAGE.latestDate,
       isEnd: true,
     },
   ],
@@ -174,10 +174,12 @@ export const handlers = [
       }
 
       const { targetId, conversationId } = await request.json()
+      const messages = messageMap.get(targetId)
       if (
         !(
           targetId === MOCK_TARGET.userId &&
-          conversationId === MOCK_CONVERSATION_ID
+          conversationId === MOCK_CONVERSATION_ID &&
+          messages
         )
       ) {
         return HttpResponse.json(
@@ -186,29 +188,7 @@ export const handlers = [
         )
       }
 
-      const conversationList: IConversationList = {
-        msgOwner: {
-          userId: 1,
-          userNickname: '길동홍',
-          userProfile: '',
-        },
-        msgTarget: {
-          userId: MOCK_TARGET.userId,
-          userNickname: MOCK_TARGET.userNickname,
-          userProfile: MOCK_TARGET.userProfile,
-          deleted: MOCK_TARGET.deleted,
-        },
-        msgList: [
-          {
-            userId: 2,
-            msgId: 1,
-            content: '안녕하세요',
-            date: '2025-05-10',
-            isEnd: true,
-          },
-        ],
-      }
-      return HttpResponse.json(conversationList, {
+      return HttpResponse.json(messages, {
         status: HTTP_STATUS.ok,
       })
     },


### PR DESCRIPTION
### 작업 내용

- 쪽지 목록 페이지 테스트 (messageList.test.tsx)
- 쪽지 페이지 테스트 (message.test.tsx)
- 테스트 코드를 작성하면서 발견한 버그도 함께 수정했습니다. 😥
  - 쪽지 답장 API 모킹 추가
  - 쪽지 삭제 API에서 전달하는 id 오류 수정
  - 케밥 케이스로 되어 있던 스타일 속성명을 카멜 케이스로 변경

### 스크린샷

**쪽지 목록 페이지**
![Screen_Shot 2025-07-03 14 38 24](https://github.com/user-attachments/assets/07655fb7-6c80-4ab8-a6dd-5907b8b60612)
![Screen_Shot 2025-07-03 14 38 32](https://github.com/user-attachments/assets/8e4a61d5-1b46-43e5-83a0-e3cff8ee5ae0)

**쪽지 페이지 (PC)**
![Screen_Shot 2025-07-03 14 38 41](https://github.com/user-attachments/assets/41992395-4126-4b39-a6d5-ad37f98002b9)

**쪽지 페이지 (모바일)**
<img width="45%" alt="Screen_Shot 2025-07-03 14 39 09" src="https://github.com/user-attachments/assets/dd49691c-47ad-46a8-bbf1-ba5d4a7c072c"/> <img width="45%" alt="Screen_Shot 2025-07-03 14 39 16" src="https://github.com/user-attachments/assets/9bb18176-a80d-4f59-8705-7935507edc91"/>
